### PR TITLE
Allow for multiple screen resolutions

### DIFF
--- a/client.js
+++ b/client.js
@@ -16,6 +16,7 @@ function getMugshotUrl( ped, cb ) {
 	setTimeout(() => {
 		// Assing the texture to a variable, unnecessary to call it twice in the DrawSprite function
 		let txdString = GetPedheadshotTxdString(mugshot);
+		let res = GetActiveScreenResolution();
 
 		const loop = setTick(() => {
 			DrawSprite(txdString, txdString, 0.045, 0.085, 0.10, 0.18, 0.0, 255, 255, 255, 1000);
@@ -33,8 +34,8 @@ function getMugshotUrl( ped, cb ) {
 					crop: {
 						offsetX: 0,
 						offsetY: 0,
-						width: 160,
-						height: 180
+						width  : res[0] / 11,
+                        			height : res[1] / 6
 					}
 				}, ( data ) => {
 					clearTick(loop);


### PR DESCRIPTION
Noticed on different resolutions the image was only half of a face, by taking the screen resolution, I divided it to get close to the same numbers you were already cropping. Tested and working on 1600x900, 1920x1080 and working perfect
Before:
![image](https://user-images.githubusercontent.com/39658424/80547328-e68edf00-8985-11ea-8a8f-b0b804b3ba0d.png)
After:
![image](https://user-images.githubusercontent.com/39658424/80547344-f3133780-8985-11ea-9378-aba85af69b76.png)